### PR TITLE
Report hmmbuild, EPA-NG and GAPPA heat tree output in MultiQC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-    - [#NN](https://github.com/nf-core/phyloplace/pull/NN) - Report hmmbuild, EPA-NG and GAPPA heat tree logs/output in MultiQC ([#3](https://github.com/nf-core/phyloplace/issues/3)) (by @erikrikarddaniel)
+    - [#63](https://github.com/nf-core/phyloplace/pull/63) - Report hmmbuild, EPA-NG and GAPPA heat tree logs/output in MultiQC ([#3](https://github.com/nf-core/phyloplace/issues/3)) (by @erikrikarddaniel)
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+    - [#NN](https://github.com/nf-core/phyloplace/pull/NN) - Report hmmbuild, EPA-NG and GAPPA heat tree logs/output in MultiQC ([#3](https://github.com/nf-core/phyloplace/issues/3)) (by @erikrikarddaniel)
+
 ### `Fixed`
 
 ### `Changed`

--- a/modules.json
+++ b/modules.json
@@ -92,7 +92,8 @@
                     "fasta_newick_epang_gappa": {
                         "branch": "master",
                         "git_sha": "f2bed902e13076698e7d59d1fedf5c083f6f17c0",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": ["subworkflows"],
+                        "patch": "subworkflows/nf-core/fasta_newick_epang_gappa/fasta_newick_epang_gappa.diff"
                     },
                     "utils_nextflow_pipeline": {
                         "branch": "master",

--- a/subworkflows/nf-core/fasta_newick_epang_gappa/fasta_newick_epang_gappa.diff
+++ b/subworkflows/nf-core/fasta_newick_epang_gappa/fasta_newick_epang_gappa.diff
@@ -1,0 +1,21 @@
+Changes in component 'nf-core/fasta_newick_epang_gappa'
+'subworkflows/nf-core/fasta_newick_epang_gappa/meta.yml' is unchanged
+Changes in 'fasta_newick_epang_gappa/main.nf':
+--- subworkflows/nf-core/fasta_newick_epang_gappa/main.nf
++++ subworkflows/nf-core/fasta_newick_epang_gappa/main.nf
+@@ -165,8 +165,10 @@
+     emit:
+     epang               = EPANG_PLACE.out.epang
+     jplace              = EPANG_PLACE.out.jplace
++    epang_log           = EPANG_PLACE.out.log
+     grafted_phylogeny   = GAPPA_GRAFT.out.newick
+     taxonomy_profile    = GAPPA_ASSIGN.out.profile
+     taxonomy_per_query  = GAPPA_ASSIGN.out.per_query
+     heattree            = GAPPA_HEATTREE.out.svg
++    hmmbuild_log        = HMMER_HMMBUILD.out.hmmbuildout
+ }
+
+'subworkflows/nf-core/fasta_newick_epang_gappa/tests/nextflow.config' is unchanged
+'subworkflows/nf-core/fasta_newick_epang_gappa/tests/main.nf.test.snap' is unchanged
+'subworkflows/nf-core/fasta_newick_epang_gappa/tests/main.nf.test' is unchanged
+************************************************************

--- a/subworkflows/nf-core/fasta_newick_epang_gappa/main.nf
+++ b/subworkflows/nf-core/fasta_newick_epang_gappa/main.nf
@@ -165,8 +165,10 @@ workflow FASTA_NEWICK_EPANG_GAPPA {
     emit:
     epang               = EPANG_PLACE.out.epang
     jplace              = EPANG_PLACE.out.jplace
+    epang_log           = EPANG_PLACE.out.log
     grafted_phylogeny   = GAPPA_GRAFT.out.newick
     taxonomy_profile    = GAPPA_ASSIGN.out.profile
     taxonomy_per_query  = GAPPA_ASSIGN.out.per_query
     heattree            = GAPPA_HEATTREE.out.svg
+    hmmbuild_log        = HMMER_HMMBUILD.out.hmmbuildout
 }

--- a/workflows/phyloplace.nf
+++ b/workflows/phyloplace.nf
@@ -15,6 +15,22 @@ include { methodsDescriptionText        } from '../subworkflows/local/utils_nfco
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    FUNCTIONS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+//
+// Re-indent every line of a block of text, for embedding as a YAML block literal (`data: |`)
+// in a MultiQC custom content file: every content line must be indented at least as much as
+// the block's first line, which raw multi-line tool log/SVG content won't be on its own.
+//
+def indentBlock(text, indent) {
+    def pad = ' ' * indent
+    text.readLines().collect { pad + it }.join('\n')
+}
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     RUN MAIN WORKFLOW
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
@@ -112,7 +128,64 @@ workflow PHYLOPLACE {
     //
     // MODULE: MultiQC
     //
+    // hmmbuild's and EPA-NG's own logs are plain text starting with '#'/free-text lines that
+    // MultiQC's custom content module would otherwise try (and fail) to parse as a YAML header,
+    // so wrap each in a small self-describing custom content yaml instead.
+    def ch_hmmbuild_mqc = FASTA_NEWICK_EPANG_GAPPA.out.hmmbuild_log
+        .collectFile { log_file ->
+            def id = log_file.baseName - '.hmmbuild'
+            def escaped = log_file.text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+            [
+                "${id}.hmmbuild_mqc.yaml",
+                """id: 'hmmbuild_${id}'
+section_name: 'HMMER hmmbuild: ${id}'
+description: 'Profile HMM construction log from hmmbuild, run when no --hmmfile is provided for the hmmer alignment method.'
+plot_type: 'html'
+data: |
+${indentBlock("<pre>${escaped}</pre>", 2)}
+"""
+            ]
+        }
+    def ch_epang_mqc = FASTA_NEWICK_EPANG_GAPPA.out.epang_log
+        .collectFile { log_file ->
+            def id = log_file.baseName - '.epa_info'
+            def escaped = log_file.text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+            [
+                "${id}.epang_mqc.yaml",
+                """id: 'epang_${id}'
+section_name: 'EPA-NG placement: ${id}'
+description: 'Phylogenetic placement run log from EPA-NG.'
+plot_type: 'html'
+data: |
+${indentBlock("<pre>${escaped}</pre>", 2)}
+"""
+            ]
+        }
+    // Reference trees with many tips can produce very large heat tree SVGs; skip embedding
+    // (rather than bloating the report) above this size and just point at the real output file.
+    def max_heattree_svg_bytes = 1_048_576
+    def ch_heattree_mqc = FASTA_NEWICK_EPANG_GAPPA.out.heattree
+        .collectFile { meta, svg_file ->
+            def size = svg_file.size()
+            def content = size <= max_heattree_svg_bytes
+                ? indentBlock(svg_file.text.replaceFirst(/^<\?xml[^>]*\?>\s*/, ''), 2)
+                : "  <p>Heat tree too large to embed (${(size / (1024 * 1024)).round(1)} MiB) &mdash; see <code>gappa/${svg_file.name}</code> in the pipeline output.</p>"
+            [
+                "${meta.id}.heattree_mqc.yaml",
+                """id: 'heattree_${meta.id}'
+section_name: 'GAPPA heat tree: ${meta.id}'
+description: 'Placement density heat tree, showing where in the reference phylogeny most query sequences were placed.'
+plot_type: 'html'
+data: |
+${content}
+"""
+            ]
+        }
+
     ch_multiqc_files = ch_multiqc_files.mix(ch_collated_versions)
+    ch_multiqc_files = ch_multiqc_files.mix(ch_hmmbuild_mqc)
+    ch_multiqc_files = ch_multiqc_files.mix(ch_epang_mqc)
+    ch_multiqc_files = ch_multiqc_files.mix(ch_heattree_mqc)
     def ch_summary_params = paramsSummaryMap(workflow, parameters_schema: "nextflow_schema.json")
     def ch_workflow_summary = channel.value(paramsSummaryMultiqc(ch_summary_params))
     ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))


### PR DESCRIPTION
<!--
# nf-core/phyloplace pull request

Many thanks for contributing to nf-core/phyloplace!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/phyloplace/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/phyloplace/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/phyloplace _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Closes the remaining ask in #3: MultiQC runs, but until now it only ever aggregated software versions, the workflow summary, and the methods description — none of the actual tool logs.

None of `hmmer`/`epa-ng`/`gappa`/`mafft`/`clustalo` have a native MultiQC module, so this wraps three outputs as MultiQC custom content instead:

- hmmbuild's `*.hmmbuild.txt` build stats (only produced when no `--hmmfile` is given for the hmmer alignment method)
- EPA-NG's `*.epa_info.log` placement run summary
- GAPPA's heat tree SVG, showing where query sequences landed in the reference phylogeny; skipped above 1 MiB (falls back to a note pointing at the real output file) since large reference trees can produce very large SVGs that would bloat the report

Raw tool logs can't be fed to MultiQC's custom content module directly: it always tries to parse leading `#` lines as a YAML header, which breaks on hmmbuild's own descriptive comments. Each is instead wrapped in a small self-describing custom content yaml (`id`/`section_name`/`plot_type: html`), matching the pattern already used for `methods_description_mqc.yaml`. Verified real rendering (not just that MultiQC didn't error) against real pipeline output using the actual MultiQC container.

`fasta_newick_epang_gappa` (a pipeline-authored subworkflow vendored through the nf-core/modules registry) needed two new emits (`hmmbuild_log`, `epang_log`) to expose these; patched and tracked via `nf-core subworkflows patch` rather than edited unpatched.

All 6 nf-test profiles verified passing against real Docker containers.
