### PR TITLE
Add --save_domtblout option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+    - [#71](https://github.com/nf-core/phyloplace/pull/71) - New `--save_domtblout` option, saving hmmsearch's per-domain hit table in "search and place" mode ([#69](https://github.com/nf-core/phyloplace/issues/69)) (by @erikrikarddaniel)
+
 ### `Fixed`
+
+    - [#71](https://github.com/nf-core/phyloplace/pull/71) - Correct the `hmmsearch` output files listed in the output documentation, where the human-readable table was listed as `*.tbl.gz` instead of `*.txt.gz` (by @erikrikarddaniel)
 
 ### `Changed`
 

--- a/conf/test_phylosearch_input.config
+++ b/conf/test_phylosearch_input.config
@@ -25,4 +25,7 @@ params {
     // Input data
     phylosearch_input   = 'https://raw.githubusercontent.com/nf-core/test-datasets/phyloplace/testdata/phylosearch_input.csv'
     search_fasta        = 'https://raw.githubusercontent.com/nf-core/test-datasets/phyloplace/testdata/domain_16s.fna'
+
+    // Exercise the optional per-domain hit table from hmmsearch
+    save_domtblout      = true
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -44,8 +44,10 @@ The MAFFT alignment strategy keeps the structure of the original reference align
   - `*.ref.hmmbuild.txt`: Log from HMM profile build.
   - `*.ref.hmm.gz`: HMM profile made from the reference alignment, if not provided using the `hmmfile` parameter.
   - `*.ref.unaligned.afa.gz`: "Unaligned", i.e. without gap characters, reference sequences in Fasta format.
-  - `*.tbl.gz`: Table format (`-tblout`) results for individual `hmmsearch` runs in "search and place" mode
-  - `*.tbl.gz`: Standard, human-readable, format results for individual `hmmsearch` runs in "search and place" mode
+  - `*.tbl.gz`: Per-sequence hit table (`--tblout`) for individual `hmmsearch` runs in "search and place" mode
+  - `*.domtbl.gz`: Per-domain hit table (`--domtblout`) for individual `hmmsearch` runs in "search and place" mode, only written when `--save_domtblout` is set.
+    Unlike the per-sequence table, this one carries alignment coordinates for each domain, which are needed to work out profile coverage or to find genes split over several ORFs.
+  - `*.txt.gz`: Standard, human-readable, format results for individual `hmmsearch` runs in "search and place" mode
   - `*.hmmrank.tsv.gz`: Summarised `hmmsearch` results
 
 </details>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -68,6 +68,17 @@ meth-dehydr,PF00389.hmm,PF00389.alnfaa,PF00389.newick,LG+F+I,PF00848.taxonomy.ts
 rnr,PF00788.hmm,,,,
 ```
 
+### Saving the per-domain hit table
+
+By default the pipeline keeps `hmmsearch`'s per-sequence hit table (`--tblout`) but not its per-domain one.
+Add `--save_domtblout` to also write the per-domain table, as one gzipped `*.domtbl.gz` file per profile in the `hmmer` output directory.
+
+```bash
+--phylosearch_input '[path to samplesheet file]' --search_fasta '[path to fasta file]' --save_domtblout
+```
+
+The per-domain table is the only output that carries alignment coordinates, so it is what you need to work out how much of a profile a hit covers, or to find a gene split over several adjacent ORFs where no single ORF covers enough of the profile to be classified on its own.
+
 ## Running the pipeline
 
 Run the pipeline with command line parameters specifying the placement parameters as follows:

--- a/main.nf
+++ b/main.nf
@@ -45,6 +45,7 @@ workflow NFCORE_PHYLOPLACE {
         phyloplace_data,
         phylosearch_data,
         sequence_fasta,
+        params.save_domtblout,
         params.multiqc_config,
         params.multiqc_logo,
         params.multiqc_methods_description,

--- a/modules.json
+++ b/modules.json
@@ -86,7 +86,7 @@
                 "nf-core": {
                     "fasta_hmmsearch_rank_fastas": {
                         "branch": "master",
-                        "git_sha": "f2bed902e13076698e7d59d1fedf5c083f6f17c0",
+                        "git_sha": "56521ad3d62f3bcc12285fe4b62ea2d574433090",
                         "installed_by": ["subworkflows"]
                     },
                     "fasta_newick_epang_gappa": {

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,6 +21,7 @@ params {
     model                       = null
     taxonomy                    = null
     search_fasta                = null
+    save_domtblout              = false
 
     // MultiQC options
     multiqc_config              = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -42,6 +42,12 @@
                     "help_text": "Sequences from this file matching an HMM profile, will be placed in the reference phylogeny corresponding to the HMM profile.",
                     "fa_icon": "fas fa-file-tsv"
                 },
+                "save_domtblout": {
+                    "type": "boolean",
+                    "description": "Save the per-domain hit table (`--domtblout`) from hmmsearch.",
+                    "help_text": "In \"search and place\" mode, also write hmmsearch's per-domain hit table, one gzipped `*.domtbl.gz` file per profile, to the `hmmer` output directory. Unlike the per-sequence table, this one carries alignment coordinates for each domain, which are needed to work out profile coverage or to find genes split over several ORFs.",
+                    "fa_icon": "fas fa-table"
+                },
                 "id": {
                     "type": "string",
                     "description": "Name of analysis",

--- a/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/main.nf
+++ b/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/main.nf
@@ -5,14 +5,15 @@ include { SEQTK_SUBSEQ    } from '../../../modules/nf-core/seqtk/subseq/main'
 workflow FASTA_HMMSEARCH_RANK_FASTAS {
 
     take:
-    ch_hmms  // channel: [ val(meta), file(hmm) ], i.e. a list of hmm profiles, each with its meta object
-    ch_fasta // channel: file(fasta), a single fasta file
+    ch_hmms         // channel: [ val(meta), file(hmm) ], i.e. a list of hmm profiles, each with its meta object
+    ch_fasta        // channel: file(fasta), a single fasta file
+    save_domtblout  // boolean: also write and emit hmmsearch's per-domain hit table (--domtblout)
 
     main:
 
     ch_hmms
         .combine(ch_fasta)
-        .map { index -> [ index[0], index[1], index[2], false, true, false ] }
+        .map { index -> [ index[0], index[1], index[2], false, true, save_domtblout ] }
         .set { ch_hmmsearch }
 
     HMMER_HMMSEARCH ( ch_hmmsearch )
@@ -43,6 +44,7 @@ workflow FASTA_HMMSEARCH_RANK_FASTAS {
     // SEQTK_SUBSEQ emits version as a topic channel
 
     emit:
-    hmmrank                 = HMMER_HMMRANK.out.hmmrank       // channel: [ [ id: 'rank' ], hmmrank_tsv ]
-    seqfastas               = SEQTK_SUBSEQ.out.sequences      // channel: [ meta, fasta ]
+    hmmrank                 = HMMER_HMMRANK.out.hmmrank             // channel: [ [ id: 'rank' ], hmmrank_tsv ]
+    seqfastas               = SEQTK_SUBSEQ.out.sequences            // channel: [ meta, fasta ]
+    domain_summary          = HMMER_HMMSEARCH.out.domain_summary    // channel: [ meta, domtbl ]
 }

--- a/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/meta.yml
+++ b/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/meta.yml
@@ -21,6 +21,10 @@ input:
       type: file
       description: |
         The input channel containing sequences to be searched and ranked
+  - save_domtblout:
+      type: boolean
+      description: |
+        Whether hmmsearch should also write and emit its per-domain hit table (--domtblout)
 output:
   - hmmrank:
       type: file
@@ -34,6 +38,12 @@ output:
         Channel containing subsets of sequences
         Structure: [ val(meta), path(fasta) ]
       pattern: "*.fa.gz"
+  - domain_summary:
+      type: file
+      description: |
+        Channel containing hmmsearch's per-domain hit table, only present when save_domtblout is true
+        Structure: [ val(meta), path(domtbl) ]
+      pattern: "*.domtbl.gz"
 authors:
   - "@erikrikarddaniel"
 maintainers:

--- a/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test
+++ b/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test
@@ -40,6 +40,7 @@ nextflow_workflow {
                 """
                 input[0] = HMMER_HMMFETCH.out.hmm
                 input[1] = Channel.fromPath("https://raw.githubusercontent.com/nf-core/test-datasets/phyloplace/testdata/domain_16s.fna")
+                input[2] = false
                 """
             }
         }
@@ -48,6 +49,52 @@ nextflow_workflow {
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(sanitizeOutput(workflow.out)).match() }
+            )
+        }
+    }
+
+    test("SSU rRNA - hmm/fasta - save_domtblout") {
+
+        setup {
+            run("HMMER_HMMFETCH") {
+                script "../../../../modules/nf-core/hmmer/hmmfetch/main.nf"
+                process {
+                    """
+                    input[0] = Channel.fromList([
+                        tuple([ id: 'arc16s' ], file("https://raw.githubusercontent.com/tseemann/barrnap/f843d17d39561eda7ce27cc43e3c6a8104aeb9ce/db/arc.hmm")),
+                        tuple([ id: 'bac16s' ], file("https://raw.githubusercontent.com/tseemann/barrnap/f843d17d39561eda7ce27cc43e3c6a8104aeb9ce/db/bac.hmm")),
+                        tuple([ id: 'euk18s' ], file("https://raw.githubusercontent.com/tseemann/barrnap/f843d17d39561eda7ce27cc43e3c6a8104aeb9ce/db/euk.hmm")),
+                        tuple([ id: 'mito12s' ], file("https://raw.githubusercontent.com/tseemann/barrnap/f843d17d39561eda7ce27cc43e3c6a8104aeb9ce/db/mito.hmm"))
+                    ])
+                    input[1] = Channel.of('16S_rRNA', '16S_rRNA', '18S_rRNA', '12S_rRNA')
+                    input[2] = []
+                    input[3] = []
+                    """
+                }
+            }
+        }
+
+        when {
+            workflow {
+                """
+                input[0] = HMMER_HMMFETCH.out.hmm
+                input[1] = Channel.fromPath("https://raw.githubusercontent.com/nf-core/test-datasets/phyloplace/testdata/domain_16s.fna")
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            // hmmsearch's --domtblout footer embeds the work directory path and a
+            // run timestamp, so its content (and gzip md5) is never reproducible
+            // across runs -- snapshot the filenames only, like fasta_newick_epang_gappa
+            // does for its own non-reproducible outputs.
+            def sanitized = sanitizeOutput(workflow.out)
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(sanitized.hmmrank).match("hmmrank") },
+                { assert snapshot(sanitized.seqfastas).match("seqfastas") },
+                { assert snapshot(workflow.out.domain_summary.collect { meta, domtbl -> [ meta, file(domtbl).name ] }.sort { it[0].id }).match("domain_summary_filenames") }
             )
         }
     }
@@ -76,6 +123,7 @@ nextflow_workflow {
                 """
                 input[0] = HMMER_HMMFETCH.out.hmm
                 input[1] = Channel.fromPath("https://raw.githubusercontent.com/nf-core/test-datasets/phyloplace/testdata/domain_16s.fna")
+                input[2] = false
                 """
             }
         }

--- a/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test.snap
@@ -1,7 +1,39 @@
 {
+    "seqfastas": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "arc16s"
+                    },
+                    "domain_16s.fnaarc16s.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117"
+                ],
+                [
+                    {
+                        "id": "bac16s"
+                    },
+                    "domain_16s.fnabac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977"
+                ],
+                [
+                    {
+                        "id": "euk18s"
+                    },
+                    "domain_16s.fnaeuk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-21T18:11:11.258078897",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
     "LSU rRNA - hmm/fasta": {
         "content": [
             {
+                "domain_summary": [
+                    
+                ],
                 "hmmrank": [
                     [
                         {
@@ -15,15 +47,18 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-12T19:10:08.534716007",
+        "timestamp": "2026-08-21T16:52:52.353601704",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "SSU rRNA - hmm/fasta": {
         "content": [
             {
+                "domain_summary": [
+                    
+                ],
                 "hmmrank": [
                     [
                         {
@@ -54,10 +89,62 @@
                 ]
             }
         ],
-        "timestamp": "2026-05-12T19:09:52.39032913",
+        "timestamp": "2026-08-21T16:52:27.022872526",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
+        }
+    },
+    "hmmrank": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "rank"
+                    },
+                    "rank.hmmrank.tsv.gz:md5,c9839df4d2ddbef1686ab52ed354ab87"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-21T18:11:11.249815077",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
+    },
+    "domain_summary_filenames": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "arc16s"
+                    },
+                    "arc16s.domtbl.gz"
+                ],
+                [
+                    {
+                        "id": "bac16s"
+                    },
+                    "bac16s.domtbl.gz"
+                ],
+                [
+                    {
+                        "id": "euk18s"
+                    },
+                    "euk18s.domtbl.gz"
+                ],
+                [
+                    {
+                        "id": "mito12s"
+                    },
+                    "mito12s.domtbl.gz"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-21T18:11:11.296683107",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -13,6 +13,7 @@ gappa/*.profile.tsv
 gappa/*.sativa.tsv
 hmmer/*.hmmbuild.txt
 hmmer/*.hmm.gz
+hmmer/*.domtbl.gz
 hmmer/*.tbl.gz
 hmmer/*.txt.gz
 multiqc/multiqc_data/fastqc_top_overrepresented_sequences_table.txt

--- a/tests/phylosearch_input.nf.test.snap
+++ b/tests/phylosearch_input.nf.test.snap
@@ -75,18 +75,23 @@
                 "gappa/bac16s.taxonomy.profile.tsv",
                 "gappa/bac16s.taxonomy.sativa.tsv",
                 "hmmer",
+                "hmmer/arc.domtbl.gz",
                 "hmmer/arc.in.hmm",
                 "hmmer/arc.tbl.gz",
                 "hmmer/arc.txt.gz",
+                "hmmer/bac16s.domtbl.gz",
                 "hmmer/bac16s.hmm",
                 "hmmer/bac16s.tbl.gz",
                 "hmmer/bac16s.txt.gz",
+                "hmmer/euk18s.domtbl.gz",
                 "hmmer/euk18s.hmm",
                 "hmmer/euk18s.tbl.gz",
                 "hmmer/euk18s.txt.gz",
+                "hmmer/euk28s.domtbl.gz",
                 "hmmer/euk28s.hmm",
                 "hmmer/euk28s.tbl.gz",
                 "hmmer/euk28s.txt.gz",
+                "hmmer/mito16s.domtbl.gz",
                 "hmmer/mito16s.tbl.gz",
                 "hmmer/mito16s.txt.gz",
                 "hmmer/rank.hmmrank.tsv.gz",
@@ -135,10 +140,10 @@
             54,
             11
         ],
-        "timestamp": "2026-06-16T10:53:19.7571168",
+        "timestamp": "2026-08-24T10:54:00.347005736",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.3"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/workflows/phyloplace.nf
+++ b/workflows/phyloplace.nf
@@ -41,6 +41,7 @@ workflow PHYLOPLACE {
     ch_phyloplace_data  // channel: [ meta: [ id: string ], data: [ alignmethod: string, queryseqfile: fasta, refseqfile: fasta, refphylogeny: newick, hmmfile: hmm, model: string, taxonomy: tsv ] ]
     ch_phylosearch_data // channel: [ meta: [ id: string, min_bitscore: int ], data: [ alignmethod: string, hmm: file, extract_hmm: file, refseqfile: fasta, refphylogeny: newick, model: string, taxonomy: tsv ] ]
     ch_sequence_fasta   // channel: sequences to search
+    save_domtblout      // boolean: also save hmmsearch's per-domain hit table (--domtblout)
     multiqc_config
     multiqc_logo
     multiqc_methods_description
@@ -70,7 +71,7 @@ workflow PHYLOPLACE {
         )
         .set { ch_search_profiles }
 
-    FASTA_HMMSEARCH_RANK_FASTAS(ch_search_profiles, ch_sequence_fasta)
+    FASTA_HMMSEARCH_RANK_FASTAS(ch_search_profiles, ch_sequence_fasta, save_domtblout)
 
     ch_phyloplace_data = FASTA_HMMSEARCH_RANK_FASTAS.out.seqfastas
         .join(


### PR DESCRIPTION
<!--
# nf-core/phyloplace pull request

Many thanks for contributing to nf-core/phyloplace!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/phyloplace/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/phyloplace/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/phyloplace _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Closes #69.

`hmmsearch`'s per-sequence hit table carries no alignment coordinates, so there was no way to work out how much of a profile a hit covers, or to find a gene split over several adjacent ORFs where no single ORF covers enough of the profile to be classified on its own. Those coordinates only exist in the per-domain table, which the pipeline never wrote and which could not be turned on from a config either: `ext.args = "--domtblout …"` produces a file the module never gzips and no declared output pattern matches, and overriding `publishDir` for `HMMER_HMMSEARCH` from a `-c` config disabled publishing for that process entirely.

The blocker was upstream: `fasta_hmmsearch_rank_fastas` hardcoded `write_domain` to `false`. [nf-core/modules#12772](https://github.com/nf-core/modules/pull/12772) added a `save_domtblout` `take:` parameter and a `domain_summary` emit, and is now merged, so this PR updates the vendored subworkflow and wires the option through.

### Changes

- **Update `fasta_hmmsearch_rank_fastas`** to `56521ad`, the merge commit of nf-core/modules#12772.
- **New `--save_domtblout` parameter** (default `false`), passed as an explicit value from `main.nf` into `PHYLOPLACE` and on to `FASTA_HMMSEARCH_RANK_FASTAS`, per the pipeline's existing convention of not reading `params.*` below `main.nf`.
- No publishing change was needed. `HMMER_HMMSEARCH` already declares `path('*.domtbl.gz'), emit: domain_summary` and gzips it, so the default `publishDir` in `conf/modules.config` lands it in `results/hmmer/`.
- **Docs**: a `### Saving the per-domain hit table` section in `docs/usage.md`, and the `*.domtbl.gz` output listed in `docs/output.md`. While there, corrected `docs/output.md`, which listed `hmmsearch`'s human-readable output as `*.tbl.gz`, a duplicate of the line above it, rather than `*.txt.gz`.

### Testing

`conf/test_phylosearch_input.config` now sets `save_domtblout = true`, so the existing pipeline test covers the new path end to end rather than adding another full pipeline run to CI. The trade-off is that the phylosearch path no longer has a test with the option off.

The table's footer embeds the work directory path and a run timestamp, so its content is never reproducible; `hmmer/*.domtbl.gz` is therefore added to `tests/.nftignore` and the snapshot records the filenames only. Verified stable by re-running the suite without `--update-snapshot`, not just recorded once.

Full `nf-test test --profile=+docker` suite passes (6/6). `nf-core pipelines lint` reports 0 failures. `nextflow lint .` is clean on 26.04.6; on the declared minimum 25.10.4 the one remaining error is pre-existing in the vendored `utils_nextflow_pipeline` subworkflow and untouched here.

### Not included

Issue #69 also mentions `SEQTK_SUBSEQ` output filenames missing a separator (`domain_16s.fnaarc.fa.gz`). That comes from the vendored `seqtk/subseq` module building its output name as `${sequences}${prefix}.${ext}.gz`, so it cannot be fixed from this pipeline with `ext.prefix`. It needs a fix in nf-core/modules and will be picked up in the next general module update here.
