### PR TITLE
Update seqtk/subseq and fasta_hmmsearch_rank_fastas (nf-core/modules#12800)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+    - [#NN](https://github.com/nf-core/phyloplace/pull/NN) - Update `seqtk/subseq` and `fasta_hmmsearch_rank_fastas` to fix output filenames glomming the input sequence filename onto the prefix ([nf-core/modules#12779](https://github.com/nf-core/modules/issues/12779)) (by @erikrikarddaniel)
     - [#68](https://github.com/nf-core/phyloplace/pull/68) - Template update to 4.1.0 (by @erikrikarddaniel)
 
 ### `Dependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-    - [#NN](https://github.com/nf-core/phyloplace/pull/NN) - Update `seqtk/subseq` and `fasta_hmmsearch_rank_fastas` to fix output filenames glomming the input sequence filename onto the prefix ([nf-core/modules#12779](https://github.com/nf-core/modules/issues/12779)) (by @erikrikarddaniel)
+    - [#73](https://github.com/nf-core/phyloplace/pull/73) - Update `seqtk/subseq` and `fasta_hmmsearch_rank_fastas` to fix output filenames glomming the input sequence filename onto the prefix ([nf-core/modules#12779](https://github.com/nf-core/modules/issues/12779)) (by @erikrikarddaniel)
     - [#68](https://github.com/nf-core/phyloplace/pull/68) - Template update to 4.1.0 (by @erikrikarddaniel)
 
 ### `Dependencies`

--- a/modules.json
+++ b/modules.json
@@ -77,7 +77,7 @@
                     },
                     "seqtk/subseq": {
                         "branch": "master",
-                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "git_sha": "183591f15495ea2e473df6e0794eb33df6567d72",
                         "installed_by": ["fasta_hmmsearch_rank_fastas"]
                     }
                 }
@@ -86,7 +86,7 @@
                 "nf-core": {
                     "fasta_hmmsearch_rank_fastas": {
                         "branch": "master",
-                        "git_sha": "106170c99010f5429b24c610f2da528e47ca3276",
+                        "git_sha": "183591f15495ea2e473df6e0794eb33df6567d72",
                         "installed_by": ["subworkflows"]
                     },
                     "fasta_newick_epang_gappa": {

--- a/modules/nf-core/seqtk/subseq/main.nf
+++ b/modules/nf-core/seqtk/subseq/main.nf
@@ -31,7 +31,7 @@ process SEQTK_SUBSEQ {
         $args \\
         $sequences \\
         $filter_list | \\
-        gzip --no-name > ${sequences}${prefix}.${ext}.gz
+        gzip --no-name > ${prefix}.${ext}.gz
     """
 
     stub:
@@ -41,6 +41,6 @@ process SEQTK_SUBSEQ {
         ext = "fq"
     }
     """
-    echo "" | gzip > ${sequences}${prefix}.${ext}.gz
+    echo "" | gzip > ${prefix}.${ext}.gz
     """
 }

--- a/modules/nf-core/seqtk/subseq/tests/main.nf.test.snap
+++ b/modules/nf-core/seqtk/subseq/tests/main.nf.test.snap
@@ -7,7 +7,7 @@
                         {
                             "id": "test"
                         },
-                        "genome.fasta.filtered.fa.gz:md5,31c95c4d686526cf002f6119bc55b2b2"
+                        "test.filtered.fa.gz:md5,31c95c4d686526cf002f6119bc55b2b2"
                     ]
                 ],
                 "1": [
@@ -22,7 +22,7 @@
                         {
                             "id": "test"
                         },
-                        "genome.fasta.filtered.fa.gz:md5,31c95c4d686526cf002f6119bc55b2b2"
+                        "test.filtered.fa.gz:md5,31c95c4d686526cf002f6119bc55b2b2"
                     ]
                 ],
                 "versions_seqtk": [
@@ -34,11 +34,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-08-26T09:12:10.98619525",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-14T10:29:32.149681094"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     },
     "sarscov2_subseq_fa_stub": {
         "content": [
@@ -48,7 +48,7 @@
                         {
                             "id": "test"
                         },
-                        "genome.fasta.filtered.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "test.filtered.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "1": [
@@ -63,7 +63,7 @@
                         {
                             "id": "test"
                         },
-                        "genome.fasta.filtered.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                        "test.filtered.fa.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
                 "versions_seqtk": [
@@ -75,10 +75,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-08-26T09:12:16.481993305",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-14T10:29:46.028543522"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
+        }
     }
 }

--- a/modules/nf-core/seqtk/subseq/tests/standard.config
+++ b/modules/nf-core/seqtk/subseq/tests/standard.config
@@ -1,5 +1,5 @@
 process {
     withName: SEQTK_SUBSEQ {
-        ext.prefix = { ".filtered" }
+        ext.prefix = { "${meta.id}.filtered" }
     }
 }

--- a/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fasta_hmmsearch_rank_fastas/tests/main.nf.test.snap
@@ -6,23 +6,23 @@
                     {
                         "id": "arc16s"
                     },
-                    "domain_16s.fnaarc16s.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117"
+                    "arc16s.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117"
                 ],
                 [
                     {
                         "id": "bac16s"
                     },
-                    "domain_16s.fnabac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977"
+                    "bac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977"
                 ],
                 [
                     {
                         "id": "euk18s"
                     },
-                    "domain_16s.fnaeuk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
+                    "euk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
                 ]
             ]
         ],
-        "timestamp": "2026-08-21T18:11:11.258078897",
+        "timestamp": "2026-08-26T09:14:14.636250271",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"
@@ -72,24 +72,24 @@
                         {
                             "id": "arc16s"
                         },
-                        "domain_16s.fnaarc16s.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117"
+                        "arc16s.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117"
                     ],
                     [
                         {
                             "id": "bac16s"
                         },
-                        "domain_16s.fnabac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977"
+                        "bac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977"
                     ],
                     [
                         {
                             "id": "euk18s"
                         },
-                        "domain_16s.fnaeuk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
+                        "euk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-08-21T16:52:27.022872526",
+        "timestamp": "2026-08-26T09:14:02.918378183",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"

--- a/tests/phylosearch_input.nf.test.snap
+++ b/tests/phylosearch_input.nf.test.snap
@@ -108,9 +108,9 @@
                 "pipeline_info",
                 "pipeline_info/nf_core_phyloplace_software_mqc_versions.yml",
                 "seqtk",
-                "seqtk/domain_16s.fnaarc.fa.gz",
-                "seqtk/domain_16s.fnabac16s.fa.gz",
-                "seqtk/domain_16s.fnaeuk18s.fa.gz"
+                "seqtk/arc.fa.gz",
+                "seqtk/bac16s.fa.gz",
+                "seqtk/euk18s.fa.gz"
             ],
             [
                 "arc.aln:md5,48e87b305ac10ecc0036ba7ab1c84c86",
@@ -129,9 +129,9 @@
                 "euk28s.hmm:md5,5686ecd69ead0cabfefb74320d1207fb",
                 "rank.hmmrank.tsv.gz:md5,c5634dcd5d13efb396e01cd8fd8324eb",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
-                "domain_16s.fnaarc.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117",
-                "domain_16s.fnabac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977",
-                "domain_16s.fnaeuk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
+                "arc.fa.gz:md5,8c00033483c62c0e64b8fc4f958eb117",
+                "bac16s.fa.gz:md5,3e2e39f8d78a5e3965f0c4dc804dd977",
+                "euk18s.fa.gz:md5,c0117af2379df85b13890efde1bcdda4"
             ],
             88,
             50,


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

## Description

Pulls in [nf-core/modules#12800](https://github.com/nf-core/modules/pull/12800) via `nf-core modules update --all --no-preview`, which fixes `seqtk/subseq`'s output filename: it used to glom the input sequence filename onto the front of `ext.prefix` with no separator (`${sequences}${prefix}.${ext}.gz`), producing names like `domain_16s.fnaarc16s.fa.gz`. It's now `${prefix}.${ext}.gz`, e.g. `arc16s.fa.gz`.

This is a pure rename -- file *content* (and its md5) is unchanged, only the output filename. `nf-core modules update` regenerated the module's own and the `fasta_hmmsearch_rank_fastas` subworkflow's vendored snapshots automatically, but this pipeline's own `tests/phylosearch_input.nf.test.snap` needed the same rename applied by hand, since nf-test only regenerates snapshots for tests it actually runs.

Verified with `nf-test test tests/phylosearch_input.nf.test --profile=+docker` (passes), `prek run -a`, and `nf-core pipelines lint` (both clean).

Drafted with help from Claude Code.
