### PR TITLE
Update the gappa examine modules to gappa 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+    - [#NN](https://github.com/nf-core/phyloplace/pull/NN) - Update `gappa/examineassign`, `gappa/examinegraft` and `gappa/examineheattree` to gappa 0.9.0, so every gappa step runs the same version and container ([nf-core/modules#12858](https://github.com/nf-core/modules/pull/12858)) (by @erikrikarddaniel)
     - [#79](https://github.com/nf-core/phyloplace/pull/79) - Publish grafted trees as `<id>.graft.newick` instead of `<id>.graft.<id>.epa_result.newick`, dropping a repetition of the name and matching the new joint outputs (by @erikrikarddaniel)
     - [#77](https://github.com/nf-core/phyloplace/pull/77) - Adopt typed `params` blocks for pipeline-specific parameters, fixing boolean options (e.g. `--save_domtblout false`) that couldn't be turned off from the command line ([#74](https://github.com/nf-core/phyloplace/issues/74)) (by @erikrikarddaniel). Raises the minimum required Nextflow version to `26.04.0`.
     - [#73](https://github.com/nf-core/phyloplace/pull/73) - Update `seqtk/subseq` and `fasta_hmmsearch_rank_fastas` to fix output filenames glomming the input sequence filename onto the prefix ([nf-core/modules#12779](https://github.com/nf-core/modules/issues/12779)) (by @erikrikarddaniel)
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | software  | previously | now       |
 | --------- | ---------- | --------- |
+| gappa     | 0.8.0      | 0.9.0     |
 | Nextflow  | >=25.10.4  | >=26.04.0 |
 | nf-schema | 2.7.2      | 2.8.0     |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-    - [#NN](https://github.com/nf-core/phyloplace/pull/NN) - Update `gappa/examineassign`, `gappa/examinegraft` and `gappa/examineheattree` to gappa 0.9.0, so every gappa step runs the same version and container ([nf-core/modules#12858](https://github.com/nf-core/modules/pull/12858)) (by @erikrikarddaniel)
+    - [#81](https://github.com/nf-core/phyloplace/pull/81) - Update `gappa/examineassign`, `gappa/examinegraft` and `gappa/examineheattree` to gappa 0.9.0, so every gappa step runs the same version and container ([nf-core/modules#12858](https://github.com/nf-core/modules/pull/12858)) (by @erikrikarddaniel)
     - [#79](https://github.com/nf-core/phyloplace/pull/79) - Publish grafted trees as `<id>.graft.newick` instead of `<id>.graft.<id>.epa_result.newick`, dropping a repetition of the name and matching the new joint outputs (by @erikrikarddaniel)
     - [#77](https://github.com/nf-core/phyloplace/pull/77) - Adopt typed `params` blocks for pipeline-specific parameters, fixing boolean options (e.g. `--save_domtblout false`) that couldn't be turned off from the command line ([#74](https://github.com/nf-core/phyloplace/issues/74)) (by @erikrikarddaniel). Raises the minimum required Nextflow version to `26.04.0`.
     - [#73](https://github.com/nf-core/phyloplace/pull/73) - Update `seqtk/subseq` and `fasta_hmmsearch_rank_fastas` to fix output filenames glomming the input sequence filename onto the prefix ([nf-core/modules#12779](https://github.com/nf-core/modules/issues/12779)) (by @erikrikarddaniel)

--- a/modules.json
+++ b/modules.json
@@ -32,17 +32,17 @@
                     },
                     "gappa/examineassign": {
                         "branch": "master",
-                        "git_sha": "9359d5e7ded9180d28a82ba1881b8ec5a6a96467",
+                        "git_sha": "7e678ba56e91b8b61b01ad8e94a6987db443f7e4",
                         "installed_by": ["fasta_newick_epang_gappa"]
                     },
                     "gappa/examinegraft": {
                         "branch": "master",
-                        "git_sha": "9359d5e7ded9180d28a82ba1881b8ec5a6a96467",
+                        "git_sha": "7e678ba56e91b8b61b01ad8e94a6987db443f7e4",
                         "installed_by": ["fasta_newick_epang_gappa"]
                     },
                     "gappa/examineheattree": {
                         "branch": "master",
-                        "git_sha": "9359d5e7ded9180d28a82ba1881b8ec5a6a96467",
+                        "git_sha": "7e678ba56e91b8b61b01ad8e94a6987db443f7e4",
                         "installed_by": ["fasta_newick_epang_gappa"]
                     },
                     "hmmer/eslalimask": {

--- a/modules/nf-core/gappa/examineassign/environment.yml
+++ b/modules/nf-core/gappa/examineassign/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::gappa=0.8.0
+  - bioconda::gappa=0.9.0

--- a/modules/nf-core/gappa/examineassign/main.nf
+++ b/modules/nf-core/gappa/examineassign/main.nf
@@ -4,8 +4,8 @@ process GAPPA_EXAMINEASSIGN {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gappa:0.8.0--h9a82719_0':
-        'quay.io/biocontainers/gappa:0.8.0--h9a82719_0' }"
+        'https://depot.galaxyproject.org/singularity/gappa:0.9.0--h077b44d_0':
+        'quay.io/biocontainers/gappa:0.9.0--h077b44d_0' }"
 
     input:
     tuple val(meta), path(jplace), path(taxonomy)

--- a/modules/nf-core/gappa/examineassign/tests/main.nf.test.snap
+++ b/modules/nf-core/gappa/examineassign/tests/main.nf.test.snap
@@ -46,15 +46,15 @@
                     [
                         "GAPPA_EXAMINEASSIGN",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-06T09:50:47.764043445",
+        "timestamp": "2026-08-31T20:55:49.294390021",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "test-gappa-examineassign-stub": {
@@ -89,15 +89,15 @@
                     [
                         "GAPPA_EXAMINEASSIGN",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-06T09:50:54.909308378",
+        "timestamp": "2026-08-31T20:55:53.721697033",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/modules/nf-core/gappa/examinegraft/environment.yml
+++ b/modules/nf-core/gappa/examinegraft/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::gappa=0.8.0
+  - bioconda::gappa=0.9.0

--- a/modules/nf-core/gappa/examinegraft/main.nf
+++ b/modules/nf-core/gappa/examinegraft/main.nf
@@ -4,8 +4,8 @@ process GAPPA_EXAMINEGRAFT {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gappa:0.8.0--h9a82719_0':
-        'quay.io/biocontainers/gappa:0.8.0--h9a82719_0' }"
+        'https://depot.galaxyproject.org/singularity/gappa:0.9.0--h077b44d_0':
+        'quay.io/biocontainers/gappa:0.9.0--h077b44d_0' }"
 
     input:
     tuple val(meta), path(jplace)

--- a/modules/nf-core/gappa/examinegraft/tests/main.nf.test.snap
+++ b/modules/nf-core/gappa/examinegraft/tests/main.nf.test.snap
@@ -14,15 +14,15 @@
                     [
                         "GAPPA_EXAMINEGRAFT",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-06T09:49:05.576434267",
+        "timestamp": "2026-08-31T20:56:02.547524327",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "test-gappa-examinegraft": {
@@ -40,15 +40,15 @@
                     [
                         "GAPPA_EXAMINEGRAFT",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-06T09:48:58.46483027",
+        "timestamp": "2026-08-31T20:55:58.116946211",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/modules/nf-core/gappa/examineheattree/environment.yml
+++ b/modules/nf-core/gappa/examineheattree/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::gappa=0.8.0
+  - bioconda::gappa=0.9.0

--- a/modules/nf-core/gappa/examineheattree/main.nf
+++ b/modules/nf-core/gappa/examineheattree/main.nf
@@ -4,8 +4,8 @@ process GAPPA_EXAMINEHEATTREE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/gappa:0.8.0--h9a82719_0':
-        'quay.io/biocontainers/gappa:0.8.0--h9a82719_0' }"
+        'https://depot.galaxyproject.org/singularity/gappa:0.9.0--h077b44d_0':
+        'quay.io/biocontainers/gappa:0.9.0--h077b44d_0' }"
 
     input:
     tuple val(meta), path(jplace)

--- a/modules/nf-core/gappa/examineheattree/tests/main.nf.test.snap
+++ b/modules/nf-core/gappa/examineheattree/tests/main.nf.test.snap
@@ -54,7 +54,7 @@
                     [
                         "GAPPA_EXAMINEHEATTREE",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             },
@@ -71,10 +71,10 @@
                 "    At 1.000: Label '1', Color #000000"
             ]
         ],
-        "timestamp": "2026-05-06T09:52:18.235753136",
+        "timestamp": "2026-08-31T20:56:07.182550046",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     },
     "test-gappa-examineheattree-stub": {
@@ -112,15 +112,15 @@
                     [
                         "GAPPA_EXAMINEHEATTREE",
                         "gappa",
-                        "0.8.0"
+                        "0.9.0"
                     ]
                 ]
             }
         ],
-        "timestamp": "2026-05-06T09:52:25.361266042",
+        "timestamp": "2026-08-31T20:56:11.975526384",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "26.04.0"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/tests/clustalo.nf.test.snap
+++ b/tests/clustalo.nf.test.snap
@@ -16,13 +16,13 @@
                     "epa-ng": "0.3.8"
                 },
                 "GAPPA_ASSIGN": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_GRAFT": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_HEATTREE": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "Workflow": {
                     "nf-core/phyloplace": "v2.2.0dev"

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -9,13 +9,13 @@
                     "epa-ng": "0.3.8"
                 },
                 "GAPPA_ASSIGN": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_GRAFT": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_HEATTREE": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "HMMER_AFAFORMATQUERY": {
                     "easel": 0.49,

--- a/tests/embedded_taxonomy.nf.test.snap
+++ b/tests/embedded_taxonomy.nf.test.snap
@@ -9,13 +9,13 @@
                     "epa-ng": "0.3.8"
                 },
                 "GAPPA_ASSIGN": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_GRAFT": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_HEATTREE": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "HMMER_AFAFORMATQUERY": {
                     "easel": 0.49,

--- a/tests/hmmfile.nf.test.snap
+++ b/tests/hmmfile.nf.test.snap
@@ -9,13 +9,13 @@
                     "epa-ng": "0.3.8"
                 },
                 "GAPPA_ASSIGN": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_GRAFT": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_HEATTREE": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "HMMER_AFAFORMATQUERY": {
                     "easel": 0.49,

--- a/tests/mafft.nf.test.snap
+++ b/tests/mafft.nf.test.snap
@@ -12,13 +12,13 @@
                     "epa-ng": "0.3.8"
                 },
                 "GAPPA_ASSIGN": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_GRAFT": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_HEATTREE": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "MAFFT_ALIGN": {
                     "mafft": 7.52,

--- a/tests/phyloplace_input.nf.test.snap
+++ b/tests/phyloplace_input.nf.test.snap
@@ -12,25 +12,25 @@
                     "epa-ng": "0.3.8"
                 },
                 "GAPPA_ASSIGN": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_EDITMERGE": {
                     "gappa": "0.9.0"
                 },
                 "GAPPA_GRAFT": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_HEATTREE": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_JOINTASSIGN": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_JOINTGRAFT": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_JOINTHEATTREE": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "HMMER_AFAFORMATQUERY": {
                     "easel": 0.49,

--- a/tests/phylosearch_input.nf.test.snap
+++ b/tests/phylosearch_input.nf.test.snap
@@ -16,13 +16,13 @@
                     "epa-ng": "0.3.8"
                 },
                 "GAPPA_ASSIGN": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_GRAFT": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_HEATTREE": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "HMMER_HMMEXTRACT": {
                     "hmmsearch": 3.4

--- a/tests/phylosearch_reftree.nf.test.snap
+++ b/tests/phylosearch_reftree.nf.test.snap
@@ -16,25 +16,25 @@
                     "epa-ng": "0.3.8"
                 },
                 "GAPPA_ASSIGN": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_EDITMERGE": {
                     "gappa": "0.9.0"
                 },
                 "GAPPA_GRAFT": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_HEATTREE": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_JOINTASSIGN": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_JOINTGRAFT": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "GAPPA_JOINTHEATTREE": {
-                    "gappa": "0.8.0"
+                    "gappa": "0.9.0"
                 },
                 "HMMER_HMMEXTRACT": {
                     "hmmsearch": 3.4

--- a/workflows/phyloplace.nf
+++ b/workflows/phyloplace.nf
@@ -31,7 +31,7 @@ include { methodsDescriptionText        } from '../subworkflows/local/utils_nfco
 //
 def indentBlock(text, indent) {
     def pad = ' ' * indent
-    text.readLines().collect { pad + it }.join('\n')
+    text.readLines().collect { line -> pad + line }.join('\n')
 }
 
 //


### PR DESCRIPTION
<!--
# nf-core/phyloplace pull request

Many thanks for contributing to nf-core/phyloplace!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/phyloplace/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/phyloplace/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/phyloplace _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

`gappa/editmerge` came in on gappa 0.9.0 with the reference-tree summaries in #79, which left the pipeline running two gappa versions and pulling two containers for one tool. [nf-core/modules#12858](https://github.com/nf-core/modules/pull/12858) bumped `gappa/examineassign`, `gappa/examinegraft` and `gappa/examineheattree` to match, so this takes that update.

The three modules change only in their version string and container tag. All eight pipeline tests pass against snapshots patched for the version alone, so 0.9.0 produces byte-identical output here — no snapshot regeneration was needed beyond the version string.

Checked before pushing: `prek run -a` clean, `nf-core pipelines lint` 286 passed / 0 failed, and `nextflow lint .` on both 26.04.0 (the declared minimum) and latest.

That lint run turned up one warning in the pipeline's own code, so it is fixed here too: `indentBlock` used the implicit closure parameter `it`, which newer Nextflow deprecates. It was the only such use, so the declared minimum now lints clean; the four warnings left at the latest version are all in template or vendored code. No CHANGELOG entry, since nothing about it is user-facing, and no snapshot moved — the full suite passes unchanged, including the MultiQC custom content that function builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDswY3eJxbJ9xnWSCQFVRG
