### PR TITLE
Carry search rows over wholesale instead of field by field

### DIFF
--- a/workflows/phyloplace.nf
+++ b/workflows/phyloplace.nf
@@ -116,17 +116,12 @@ workflow PHYLOPLACE {
                 .filter { it -> it.data.alignmethod && it.data.refseqfile && it.data.refphylogeny }
                 .map { it -> [ [ id: it.meta.id ], it ] }
         )
-        .map { it -> [
-            meta: it[2].meta,
-            data: [
-                alignmethod: it[2].data.alignmethod,
-                queryseqfile: it[1],
-                refseqfile: it[2].data.refseqfile,
-                refphylogeny: it[2].data.refphylogeny,
-                model: it[2].data.model,
-                taxonomy: it[2].data.taxonomy,
-                reftreename: it[2].data.reftreename
-            ]
+        // Carry the search row over wholesale, overriding only the query sequences the search
+        // produced. Listing the fields out instead silently drops any column added to the sample
+        // sheet later, since nothing checks that the two lists agree.
+        .map { _id, queryseqfile, row -> [
+            meta: row.meta,
+            data: row.data + [ queryseqfile: queryseqfile ]
         ] }
         .mix(ch_phyloplace_data)
 


### PR DESCRIPTION
<!--
# nf-core/phyloplace pull request

Many thanks for contributing to nf-core/phyloplace!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/phyloplace/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/phyloplace/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/phyloplace _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Follow-up to #79, removing the shape of the bug it uncovered rather than just the instance.

The map that turns a *search* row into a *placement* row in `workflows/phyloplace.nf` listed every field out by hand. That is how `reftreename` came to be missing in search-and-place mode: the column was added to the sample sheet, reached that map, and went no further — silently, because nothing checks that the two lists agree. CI stayed green because no two rows of the phylosearch sample sheet shared a reference tree, so no group could form to expose it.

`#79` fixed the instance by adding the field to the list. This copies the row instead and overrides only what the search actually produced:

```groovy
.map { _id, queryseqfile, row -> [
    meta: row.meta,
    data: row.data + [ queryseqfile: queryseqfile ]
] }
```

Eleven lines become four, a column added later cannot be dropped there again, and it matches the idiom already used a few lines below, where `CUSTOM_RESOLVETAXONOMY`'s results are folded back with `row.data + [ ... ]`.

Two fields the search rows carry, `hmm` and `extract_hmm`, now travel further than before. They are inert: `FASTA_NEWICK_EPANG_GAPPA` reads only the keys it names, and `hmmfile` — which it does read — is not among them, so the build-an-HMM branch is taken exactly as before.

I audited the other row constructions while here. The two in `PIPELINE_INITIALISATION` build rows from the positional output of `samplesheetToList`, so there is no map to merge from, and Nextflow errors on an arity mismatch if a schema column is added without updating them. The params-only mode has no source map either. This was the only site where the idiom applies.

No CHANGELOG entry: there is no behaviour change, so nothing here reaches a user. The full nf-test suite passes with no snapshot updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDswY3eJxbJ9xnWSCQFVRG
