### PR TITLE
Use relative cross-doc links now that website#4385 has landed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+    - [#NN](https://github.com/nf-core/phyloplace/pull/NN) - Use relative links between our own docs pages again, now that a website fix means they resolve correctly, instead of absolute links that silently pointed to the released docs ([#83](https://github.com/nf-core/phyloplace/issues/83)) (by @erikrikarddaniel)
     - [#71](https://github.com/nf-core/phyloplace/pull/71) - Correct the `hmmsearch` output files listed in the output documentation, where the human-readable table was listed as `*.tbl.gz` instead of `*.txt.gz` (by @erikrikarddaniel)
 
 ### `Changed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-    - [#NN](https://github.com/nf-core/phyloplace/pull/NN) - Use relative links between our own docs pages again, now that a website fix means they resolve correctly, instead of absolute links that silently pointed to the released docs ([#83](https://github.com/nf-core/phyloplace/issues/83)) (by @erikrikarddaniel)
+    - [#84](https://github.com/nf-core/phyloplace/pull/84) - Use relative links between our own docs pages again, now that a website fix means they resolve correctly, instead of absolute links that silently pointed to the released docs ([#83](https://github.com/nf-core/phyloplace/issues/83)) (by @erikrikarddaniel)
     - [#71](https://github.com/nf-core/phyloplace/pull/71) - Correct the `hmmsearch` output files listed in the output documentation, where the human-readable table was listed as `*.tbl.gz` instead of `*.txt.gz` (by @erikrikarddaniel)
 
 ### `Changed`

--- a/docs/output.md
+++ b/docs/output.md
@@ -20,7 +20,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 
 ### Taxonomy
 
-When `--refseqfile` is FASTA and `--taxonomy` is not given, taxonomy is instead derived from each reference sequence's own header (see [the usage documentation](https://nf-co.re/phyloplace/usage#deriving-taxonomy-from-fasta-headers)).
+When `--refseqfile` is FASTA and `--taxonomy` is not given, taxonomy is instead derived from each reference sequence's own header (see [the usage documentation](usage.md#deriving-taxonomy-from-fasta-headers)).
 Headers are stripped down to a bare id in the process, regardless of whether taxonomy came from a header or an explicit `--taxonomy` file.
 
 <details markdown="1">
@@ -133,7 +133,7 @@ Third, if a classification of the reference sequences is available (see [Taxonom
 
 </details>
 
-When rows of the sample sheet share a `reftreename` (see [Summarising several profiles on one reference tree](https://nf-co.re/phyloplace/usage#summarising-several-profiles-on-one-reference-tree)), the same three summaries are also produced once for the group as a whole, on top of the per-row ones above.
+When rows of the sample sheet share a `reftreename` (see [Summarising several profiles on one reference tree](usage.md#summarising-several-profiles-on-one-reference-tree)), the same three summaries are also produced once for the group as a whole, on top of the per-row ones above.
 The group's placements are first merged into a single jplace file, since `gappa examine graft` summarises each jplace file it is given separately, and then grafted, classified and heat-treed from that.
 
 <details markdown="1">

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -129,7 +129,7 @@ Add `--save_domtblout` to also write the per-domain table, as one gzipped `*.dom
 ```
 
 The per-domain table is the only output that carries alignment coordinates, so it is what you need to work out how much of a profile a hit covers, or to find a gene split over several adjacent ORFs where no single ORF covers enough of the profile to be classified on its own.
-Setting the flag also adds coordinate and length columns to the ranked summary in `*.hmmrank.tsv.gz`, which is usually the easier place to read them off; see the [output documentation](https://nf-co.re/phyloplace/output) for what each column means.
+Setting the flag also adds coordinate and length columns to the ranked summary in `*.hmmrank.tsv.gz`, which is usually the easier place to read them off; see the [output documentation](output.md) for what each column means.
 
 ## Running the pipeline
 


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/phyloplace/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/phyloplace _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Closes #83.

[nf-core/website#4385](https://github.com/nf-core/website/pull/4385) fixed the 404 that relative links between a pipeline's own docs pages used to hit on the website (docs pages are served at trailing-slash URLs, and the site's markdown rewriter only stripped the `.md` extension, leaving the href one level too deep).

We worked around that in #79 by hardcoding absolute `https://nf-co.re/phyloplace/...` links. That workaround is now unnecessary, and actually worse than the relative form: an absolute link always resolves to the **released** docs, so a link to a section that only exists on `dev` returns 200 and silently drops the reader at the top of the page with no anchor jump, instead of the visible 404 the workaround was meant to avoid.

This PR reverts the three cross-references added in #79 back to relative links:

- `docs/output.md` → `docs/usage.md#deriving-taxonomy-from-fasta-headers`
- `docs/output.md` → `docs/usage.md#summarising-several-profiles-on-one-reference-tree`
- `docs/usage.md` → `docs/output.md`

Left absolute, per #83: the `docs/usage.md` template banner (deliberately sends readers off GitHub), the parameters page (no markdown source to link relatively to), and README.md/docs/CONTRIBUTING.md (read mostly on GitHub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013B7M5rFeGkzB37H4qsxb5x
