### PR TITLE
Trim wordy comments and docs from the 2.2.0 diff

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -65,15 +65,8 @@ The MAFFT alignment strategy keeps the structure of the original reference align
     Unlike the per-sequence table, this one carries alignment coordinates for each domain, which are needed to work out profile coverage or to find genes split over several ORFs.
   - `*.txt.gz`: Standard, human-readable, format results for individual `hmmsearch` runs in "search and place" mode
   - `*.hmmrank.tsv.gz`: Summarised `hmmsearch` results, one row per sequence and profile, ranking the profiles that matched each sequence.
-    When `--save_domtblout` is set, each row also carries the lengths of the sequence (`tlen`) and the profile (`qlen`), plus four columns for each of the three coordinate sets HMMER reports: `hmm` (position in the profile), `ali` (the aligned part of the sequence) and `env` (the wider region the alignment is likely to lie within).
-    For a set `x`, `x_from` and `x_to` are the outer bounds of the match, while `x_len` is how much of that span the sequence's domains actually cover, so a hit whose domains are scattered has an `x_len` well below `x_to - x_from`.
-    `x_n_islands` counts the separate stretches that coverage falls into: 1 for a single continuous match, more when the domains are broken up.
-    The two lengths are the denominators for coverage, each belonging to a different coordinate set: `hmm` positions are in the profile, so `hmm_len / qlen` is the proportion of the profile a hit covers, while `ali` and `env` positions are in the sequence, so `ali_len / tlen` is the proportion of the sequence the alignment takes up (`env_len / tlen` for the looser envelope).
-    Mixing them, say `hmm_len / tlen`, compares a profile position against a sequence length and means nothing.
-    For the profile, `hmm_from - 1` and `qlen - hmm_to` also tell you how much is missing from each of its ends.
-    Coverage counts every domain HMMER reported, however weak on its own; which sequences are reported at all is still decided by the full-sequence scores, exactly as when the coordinates are not requested.
-    A sequence is reported at all on the per-sequence threshold, whereas a domain has to clear the per-domain one, so a hit can be ranked here with no domain records behind it at all.
-    Those rows carry `NA` in every column above, which is deliberate: an empty value is the clearest signal that `hmmsearch` reported no domains for the hit, and it keeps such rows distinguishable from ones whose coordinates were genuinely computed.
+    When `--save_domtblout` is set, each row also carries the sequence and profile lengths (`tlen`, `qlen`) and, for each of the `hmm`, `ali` and `env` coordinate sets, the match bounds (`x_from`, `x_to`), the covered length (`x_len`) and the number of separate stretches it falls into (`x_n_islands`) -- e.g. profile coverage is `hmm_len / qlen`.
+    Rows whose hit cleared the per-sequence threshold but has no domain records of its own (possible, since `--domtblout` uses a stricter per-domain threshold) carry `NA` in all of these columns instead.
 
 </details>
 

--- a/workflows/phyloplace.nf
+++ b/workflows/phyloplace.nf
@@ -34,20 +34,14 @@ def indentBlock(text, indent) {
     text.readLines().collect { line -> pad + line }.join('\n')
 }
 
-//
-// Whether a reference sequence file is FASTA -- only FASTA headers have room for embedded
-// taxonomy text (GTDB-style `>id taxonomy;string`), so this gates whether
-// CUSTOM_RESOLVETAXONOMY is worth invoking on a given row at all.
-//
+// Only FASTA headers can carry embedded taxonomy text (GTDB-style `>id taxonomy;string`),
+// so this gates whether CUSTOM_RESOLVETAXONOMY runs on a row at all.
 def isFastaFile(path) {
     path.withReader { reader -> reader.readLine()?.trim()?.startsWith('>') } ?: false
 }
 
-//
-// Wrap a GAPPA heat tree SVG in a MultiQC custom content file. Reference trees with many
-// tips can produce very large SVGs; skip embedding (rather than bloating the report) above
-// this size and just point at the real output file.
-//
+// Wrap a GAPPA heat tree SVG in a MultiQC custom content file, skipping embedding above
+// max_svg_bytes (linking to the real file instead) to avoid bloating the report.
 def heattreeMqc(name, svg_file, section, description) {
     def max_svg_bytes = 1_048_576
     def size = svg_file.size()
@@ -116,29 +110,24 @@ workflow PHYLOPLACE {
                 .filter { it -> it.data.alignmethod && it.data.refseqfile && it.data.refphylogeny }
                 .map { it -> [ [ id: it.meta.id ], it ] }
         )
-        // Carry the search row over wholesale, overriding only the query sequences the search
-        // produced. Listing the fields out instead silently drops any column added to the sample
-        // sheet later, since nothing checks that the two lists agree.
+        // Carry the row over wholesale, overriding only queryseqfile -- listing fields out
+        // instead silently drops any column added to the sample sheet later.
         .map { _id, queryseqfile, row -> [
             meta: row.meta,
             data: row.data + [ queryseqfile: queryseqfile ]
         ] }
         .mix(ch_phyloplace_data)
 
-    // Compare what the sample sheet declared, not what CUSTOM_RESOLVETAXONOMY resolves: rows
-    // deriving taxonomy from identical reference sequences each get their own resolved file,
-    // equal in content but not in path, and the group check below would reject them.
+    // Compare the *declared* taxonomy, not the resolved file path -- rows deriving taxonomy
+    // from identical refseqfiles get distinct resolved paths, which would wrongly fail the
+    // group check below.
     def ch_declared_taxonomy = ch_phyloplace_data
         .map { row -> [ row.meta.id, row.data.taxonomy ? row.data.taxonomy.toString() : '' ] }
 
     //
-    // MODULE: Derive taxonomy from refseqfile's own FASTA headers (GTDB-style
-    // `>id taxonomy;string`) when no --taxonomy file was given, instead of just
-    // proceeding without any taxonomic classification. Only applies when refseqfile
-    // is itself FASTA -- other HMMER-supported formats have no room for embedded
-    // taxonomy text and are passed through unchanged. Headers are stripped down to a
-    // bare id regardless, since some downstream tools (EPA-NG, GAPPA) keep the whole
-    // header line as the leaf name rather than just the first token.
+    // MODULE: Derive taxonomy from refseqfile's own FASTA headers when no --taxonomy was
+    // given (see isFastaFile above). Headers are stripped to a bare id either way, since
+    // EPA-NG/GAPPA otherwise use the whole header line as the leaf name.
     //
     ch_phyloplace_data
         .branch { row ->
@@ -151,10 +140,8 @@ workflow PHYLOPLACE {
         ch_pp_by_format.fasta.map { row -> [ row.meta, row.data.taxonomy ?: [], row.data.refseqfile, false ] }
     )
 
-    // --taxonomy is fully optional, so an empty resolved file (no embedded text
-    // found anywhere, same as no --taxonomy given at all) means "no taxonomy" --
-    // reset it to `[]` to keep GAPPA_ASSIGN's own ext.when skip working, rather than
-    // handing it a real-but-empty file it would otherwise try (and fail) to use.
+    // An empty resolved file means "no taxonomy found" -- reset to `[]` so GAPPA_ASSIGN's
+    // ext.when skip still works, instead of handing it a real-but-empty file it would fail on.
     CUSTOM_RESOLVETAXONOMY.out.warnings.subscribe { _meta, warnings_file ->
         def text = warnings_file.text.trim()
         if (text) log.warn(text)
@@ -180,10 +167,10 @@ workflow PHYLOPLACE {
     FASTA_NEWICK_EPANG_GAPPA(ch_phyloplace_data)
 
     //
-    // MODULES: Summarise placements per reference tree, on top of the per-row summaries
-    // above. `gappa examine assign` and `heat-tree` merge several jplace files themselves,
-    // but `graft` does not, so the group is merged first and all three run off the merged
-    // file. Single-row groups are dropped; their joint output would only repeat the per-row one.
+    // MODULES: Summarise placements per reference tree too. `graft` can't merge several
+    // jplace files itself (unlike assign/heat-tree), so the group is merged first and all
+    // three run off that; single-row groups are dropped since their joint output would just
+    // repeat the per-row one.
     //
     def ch_reftree_groups = ch_phyloplace_data
         .filter { row -> row.data.reftreename }
@@ -197,9 +184,8 @@ workflow PHYLOPLACE {
         .groupTuple()
         .filter { _reftreename, rows -> rows.size() > 1 }
         .map { reftreename, rows ->
-            // `gappa examine assign` takes a single --taxon-file, so the group has to agree
-            // on one. Stop rather than pick: classifying the whole group by whichever row
-            // came first is a wrong answer, not a smaller problem.
+            // `gappa examine assign` takes one --taxon-file, so the group must agree on one --
+            // stop rather than silently classifying by whichever row came first.
             if (rows.collect { r -> r.declared_taxonomy }.unique().size() > 1) {
                 error(
                     "Rows grouped under reftreename '${reftreename}' declare different taxonomy files, " +


### PR DESCRIPTION
<!--
# nf-core/phyloplace pull request

Many thanks for contributing to nf-core/phyloplace!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/phyloplace/tree/master/docs/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).

## Description

A pre-release read-through of everything merged since 2.1.0 (#71, #72, #75, #77, #79, #82, #84, #85) turned up two spots that had grown wordier than needed, reviewers had flagged this pattern before:

- `docs/output.md`'s `*.hmmrank.tsv.gz` bullet had grown to nine sentences, well beyond every sibling bullet in that same output-file list, and duplicated detail already documented in `hmmer/hmmrank`'s own `meta.yml`. Trimmed to two sentences, keeping the profile-coverage formula (`hmm_len / qlen`) and the `NA` semantics.
- Several `workflows/phyloplace.nf` comments added in #75/#79 (`isFastaFile`, `heattreeMqc`, the taxonomy-resolution and reftree-grouping blocks) stated their point more elaborately than needed. Trimmed each while keeping every underlying fact.

No behavioral change, no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dpvh3T7aVgU5XyjqcYQLQD
